### PR TITLE
Fix tests stubs

### DIFF
--- a/stubs/test.stub
+++ b/stubs/test.stub
@@ -8,7 +8,7 @@ use Tests\TestCase;
 
 class {{ class }} extends TestCase
 {
-    public function it_can_test()
+    public function test_example()
     {
     }
 }

--- a/stubs/test.unit.stub
+++ b/stubs/test.unit.stub
@@ -6,7 +6,7 @@ use PHPUnit\Framework\TestCase;
 
 class {{ class }} extends TestCase
 {
-    public function it_can_test()
+    public function test_example()
     {
         $this->assertTrue(true);
     }


### PR DESCRIPTION
"it_can_test" not a valid name for test methods. PHPUnit says:

> No tests found in class "Tests\Unit\CaptionShortcodeTest". [Screenshot](https://user-images.githubusercontent.com/23292709/78604548-a34bbf80-7862-11ea-9dfb-2d30c0f787fe.png)
