### PR TITLE
Publish service provider stub

### DIFF
--- a/stubs/provider.stub
+++ b/stubs/provider.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Support\ServiceProvider;
+
+class {{ class }} extends ServiceProvider
+{
+    public function register(): void
+    {
+    }
+
+    public function boot(): void
+    {
+    }
+}

--- a/stubs/provider.stub
+++ b/stubs/provider.stub
@@ -6,11 +6,11 @@ use Illuminate\Support\ServiceProvider;
 
 class {{ class }} extends ServiceProvider
 {
-    public function register(): void
+    public function register()
     {
     }
 
-    public function boot(): void
+    public function boot()
     {
     }
 }


### PR DESCRIPTION
I wasn't sure about adding the return type since most of your other stubs don't have return types. However, as far as I am aware, service providers don't return anything (or if they do, the value returned is never used).

This is a companion to https://github.com/laravel/framework/pull/39491.