### PR TITLE
Remove docblock from policy method

### DIFF
--- a/stubs/policy.stub
+++ b/stubs/policy.stub
@@ -40,13 +40,6 @@ class {{ class }}
         //
     }
 
-    /**
-     * Determine whether the user can permanently delete the model.
-     *
-     * @param  \{{ namespacedUserModel }}  $user
-     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
-     * @return mixed
-     */
     public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }})
     {
         //


### PR DESCRIPTION
I assume this docblock should be removed like all other docblock that have been removed.