### PR TITLE
Add void return type to migration stubs

### DIFF
--- a/stubs/migration.create.stub
+++ b/stubs/migration.create.stub
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('{{ table }}', function (Blueprint $table) {
             $table->id();

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    public function up()
+    public function up(): void
     {
     }
 };

--- a/stubs/migration.update.stub
+++ b/stubs/migration.update.stub
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::table('{{ table }}', function (Blueprint $table) {
         });


### PR DESCRIPTION
added void return type to migration classes

## laravel stub
<img width="561" alt="image" src="https://user-images.githubusercontent.com/26627088/180949624-46ae3f26-eecc-4d2a-b32f-6858258bb581.png">


## new stub
<img width="243" alt="image" src="https://user-images.githubusercontent.com/26627088/180949785-c63027ca-a62e-47a2-a453-d84d2e6a8f19.png">
