### PR TITLE
Update request stub to use generics

### DIFF
--- a/stubs/request.stub
+++ b/stubs/request.stub
@@ -6,6 +6,9 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class {{ class }} extends FormRequest
 {
+    /**
+     * @return array<string, mixed>
+     */
     public function rules(): array
     {
         return [];


### PR DESCRIPTION
This is already used in the default laravel stubs

https://github.com/laravel/framework/blob/9.x/src/Illuminate/Foundation/Console/stubs/request.stub#L22