### PR TITLE
remove unnecessary dockblocks

### DIFF
--- a/stubs/mail.stub
+++ b/stubs/mail.stub
@@ -13,46 +13,26 @@ class {{ class }} extends Mailable
 {
     use Queueable, SerializesModels;
 
-    /**
-     * Create a new message instance.
-     *
-     * @return void
-     */
-    public function __construct()
+    public function __construct(): void
     {
         //
     }
 
-    /**
-     * Get the message envelope.
-     *
-     * @return \Illuminate\Mail\Mailables\Envelope
-     */
-    public function envelope()
+    public function envelope(): Envelope
     {
         return new Envelope(
             subject: '{{ subject }}',
         );
     }
 
-    /**
-     * Get the message content definition.
-     *
-     * @return \Illuminate\Mail\Mailables\Content
-     */
-    public function content()
+    public function content(): Content
     {
         return new Content(
             markdown: 'markdown.view.name',
         );
     }
 
-    /**
-     * Get the attachments for the message.
-     *
-     * @return array
-     */
-    public function attachments()
+    public function attachments(): array
     {
         return [];
     }


### PR DESCRIPTION
these dockblocks don't add any value, since they are only specifying the return types, which don't contain any generics or advanced type notation.
they can be simply replaced with return type definitions.