### PR TITLE
Add new laravel11 stubs

### DIFF
--- a/stubs/cast.inbound.stub
+++ b/stubs/cast.inbound.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Database\Eloquent\CastsInboundAttributes;
+
+class {{ class }} implements CastsInboundAttributes
+{
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return $value;
+    }
+}

--- a/stubs/cast.stub
+++ b/stubs/cast.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class {{ class }} implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return $value;
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    {
+        return $value;
+    }
+}

--- a/stubs/class.invokable.stub
+++ b/stubs/class.invokable.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+class {{ class }}
+{
+    public function __invoke(): void
+    {
+
+    }
+}

--- a/stubs/class.stub
+++ b/stubs/class.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+class {{ class }}
+{
+
+}

--- a/stubs/controller.nested.singleton.api.stub
+++ b/stubs/controller.nested.singleton.api.stub
@@ -1,0 +1,31 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use {{ namespacedParentModel }};
+
+class {{ class }} extends Controller
+{
+    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): never
+    {
+        abort(404);
+    }
+
+    public function show({{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    public function destroy({{ parentModel }} ${{ parentModelVariable }}): never
+    {
+        abort(404);
+    }
+}

--- a/stubs/controller.nested.singleton.stub
+++ b/stubs/controller.nested.singleton.stub
@@ -1,0 +1,41 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use {{ namespacedParentModel }};
+
+class {{ class }} extends Controller
+{
+    public function create({{ parentModel }} ${{ parentModelVariable }}): never
+    {
+        abort(404);
+    }
+
+    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }}): never
+    {
+        abort(404);
+    }
+
+    public function show({{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    public function edit({{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    public function destroy({{ parentModel }} ${{ parentModelVariable }}): never
+    {
+        abort(404);
+    }
+}

--- a/stubs/controller.singleton.api.stub
+++ b/stubs/controller.singleton.api.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    public function store(Request $request): never
+    {
+        abort(404);
+    }
+
+    public function show()
+    {
+        //
+    }
+
+    public function update(Request $request)
+    {
+        //
+    }
+
+    public function destroy(): never
+    {
+        abort(404);
+    }
+}

--- a/stubs/controller.singleton.stub
+++ b/stubs/controller.singleton.stub
@@ -1,0 +1,39 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    public function create(): never
+    {
+        abort(404);
+    }
+
+    public function store(Request $request): never
+    {
+        abort(404);
+    }
+
+    public function show()
+    {
+        //
+    }
+
+    public function edit()
+    {
+        //
+    }
+
+    public function update(Request $request)
+    {
+        //
+    }
+
+    public function destroy(): never
+    {
+        abort(404);
+    }
+}

--- a/stubs/enum.backed.stub
+++ b/stubs/enum.backed.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+enum {{ class }}: {{ type }}
+{
+    //
+}

--- a/stubs/enum.stub
+++ b/stubs/enum.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+enum {{ class }}
+{
+    //
+}

--- a/stubs/markdown-mail.stub
+++ b/stubs/markdown-mail.stub
@@ -1,0 +1,42 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class {{ class }} extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct()
+    {
+        //
+    }
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: '{{ subject }}',
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            markdown: '{{ view }}',
+        );
+    }
+
+    /**
+     * @return array<int, \Illuminate\Mail\Mailables\Attachment>
+     */
+    public function attachments(): array
+    {
+        return [];
+    }
+}

--- a/stubs/markdown-notification.stub
+++ b/stubs/markdown-notification.stub
@@ -1,0 +1,35 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class {{ class }} extends Notification
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        //
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)->markdown('{{ view }}');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/stubs/notification.stub
+++ b/stubs/notification.stub
@@ -1,0 +1,38 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class {{ class }} extends Notification
+{
+    use Queueable;
+
+    public function __construct()
+    {
+        //
+    }
+
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+                    ->line('The introduction to the notification.')
+                    ->action('Notification Action', url('/'))
+                    ->line('Thank you for using our application!');
+    }
+
+    public function toArray(object $notifiable): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/stubs/observer.plain.stub
+++ b/stubs/observer.plain.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+class {{ class }}
+{
+    //
+}

--- a/stubs/observer.stub
+++ b/stubs/observer.stub
@@ -1,0 +1,33 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+
+class {{ class }}
+{
+    public function created({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    public function updated({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    public function deleted({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    public function restored({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+
+    public function forceDeleted({{ model }} ${{ modelVariable }}): void
+    {
+        //
+    }
+}

--- a/stubs/scope.stub
+++ b/stubs/scope.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class {{ class }} implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        //
+    }
+}

--- a/stubs/trait.stub
+++ b/stubs/trait.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+trait {{ class }}
+{
+    //
+}

--- a/stubs/view-component.stub
+++ b/stubs/view-component.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace {{ namespace }};
+
+use Closure;
+use Illuminate\View\Component;
+use Illuminate\Contracts\View\View;
+
+class {{ class }} extends Component
+{
+    public function __construct()
+    {
+        //
+    }
+
+    public function render(): View|Closure|string
+    {
+        return {{ view }};
+    }
+}

--- a/tests/StubPublishCommandTest.php
+++ b/tests/StubPublishCommandTest.php
@@ -1,8 +1,11 @@
 <?php
 
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\File;
 
+use function PHPUnit\Framework\assertFileDoesNotExist;
 use function PHPUnit\Framework\assertFileEquals;
+use function PHPUnit\Framework\assertFileExists;
 
 it('can publish stubs', function () {
     $targetStubsPath = $this->app->basePath('stubs');
@@ -16,4 +19,28 @@ it('can publish stubs', function () {
     $publishedStubPath = $targetStubsPath . '/migration.stub';
 
     assertFileEquals($stubPath, $publishedStubPath);
+});
+
+it('can publish laravel 11 stubs', function () {
+    App::shouldReceive('version')->andReturn('11');
+
+    $targetStubsPath = $this->app->basePath('stubs');
+
+    File::deleteDirectory($targetStubsPath);
+
+    $this->artisan('spatie-stub:publish')->assertExitCode(0);
+
+    assertFileExists($targetStubsPath . '/enum.stub');
+});
+
+it('will not publish laravel 11 stubs for laravel 10 and lower', function () {
+    App::shouldReceive('version')->andReturn('10');
+
+    $targetStubsPath = $this->app->basePath('stubs');
+
+    File::deleteDirectory($targetStubsPath);
+
+    $this->artisan('spatie-stub:publish')->assertExitCode(0);
+
+    assertFileDoesNotExist($targetStubsPath . '/enum.stub');
 });


### PR DESCRIPTION
this adds the newly added stubs for Laravel 11 including `class`, `enum`, and others.

this also tests that they are only published on applications running Laravel 11 and higher.