### PR TITLE
Simplify request and factory

### DIFF
--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -3,7 +3,6 @@
 namespace {{ factoryNamespace }};
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 use {{ namespacedModel }};
 
 class {{ model }}Factory extends Factory

--- a/stubs/factory.stub
+++ b/stubs/factory.stub
@@ -3,12 +3,9 @@
 namespace {{ factoryNamespace }};
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use {{ namespacedModel }};
 
 class {{ model }}Factory extends Factory
 {
-    protected $model = {{ model }}::class;
-
     public function definition()
     {
         return [

--- a/stubs/request.stub
+++ b/stubs/request.stub
@@ -6,9 +6,6 @@ use Illuminate\Foundation\Http\FormRequest;
 
 class {{ class }} extends FormRequest
 {
-    /**
-     * @return array<string, mixed>
-     */
     public function rules(): array
     {
         return [];


### PR DESCRIPTION
this removes a weird unused import in the `factory`, and the unnecessary override of `model` property, and an unnecessary docblock in the `request` stub.